### PR TITLE
Add some info and links related to FMI 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,12 +78,17 @@ FMI 3.0  development is currently in Alpha phase. General information on the FMI
 
 **Warning: FMI 3.0 is still under heavy development, and most of the tools listed in the following they support it only in an experimental way. If you want stable tools, use FMI 2 for the time being.**
 
-Some of the libraries listed in the previous section also have prototypal support for FMI 3 alpha: 
+Some of the projects listed in the previous section also have prototypal support for FMI 3 alpha: 
 
-- **Python:** [fmpy](https://github.com/CATIA-Systems/FMPy)  some support for FMI 3 is available in the [`develop`](https://github.com/CATIA-Systems/FMPy/tree/develop) branch.
-- **Simulink:** [FMIKit-Simulink](https://github.com/CATIA-Systems/FMIKit-Simulink) - Experimental export of 3.0 FMUs seems available with `grtfmi.tlc` target since `v2.8-alpha.1`, but it  still does not does not comply with FMI `3.0-alpha.3` specification. 
-- **Examples**: [Reference-FMUs](https://github.com/modelica/Reference-FMUs) : `3.0-alpha.3` examples FMUs are available, including examples for new co-simulation features such as scheduled co-simulation and early return in co-simulation.
-
+- **Examples**: 
+  - [Reference-FMUs](https://github.com/modelica/Reference-FMUs) : `3.0-alpha.3` examples FMUs are available, including examples for new co-simulation features such as scheduled co-simulation and early return in co-simulation.
+  - [PMSFIT/FMI30TestFMUs](https://github.com/PMSFIT/FMI30TestFMUs) : Some examples FMUs based on the draft FMI 3.0 specificatiion are available, including features such as binary variables.
+- **Python:** 
+  - [fmpy](https://github.com/CATIA-Systems/FMPy) - Some support for FMI 3 is available since version 0.2.19, while for the latest features you can check the [`develop`](https://github.com/CATIA-Systems/FMPy/tree/develop) branch.
+- **Simulink:** 
+  - [FMIKit-Simulink](https://github.com/CATIA-Systems/FMIKit-Simulink) - Experimental export of 3.0 FMUs seems available with `grtfmi.tlc` target since `v2.8-alpha.1`, but it  still does not does not comply with FMI `3.0-alpha.3` specification. 
+- **Formal models**
+  - [FMI-VDM-Model](https://github.com/INTO-CPS-Association/FMI-VDM-Model) - [VDM](https://en.wikipedia.org/wiki/Vienna_Development_Method) formal models for the FMI3.0 specification.
 
 ## Community
 

--- a/README.md
+++ b/README.md
@@ -7,30 +7,38 @@ See the [official FMI website](http://fmi-standard.org/) for the official specif
 
 ## Contents
 
-- [Libraries](#section)
-  - [C](#c)
-  - [C++](#c-1)
-  - [Python](#python)
-  - [Java](#java)
-  - [MATLAB/Simulink](#matlabsimulink)
-  - [Rust](#rust)
-- [Tools](#tools) 
+- [FMI 2](#fmi-2)
+  - [Libraries](#libraries)
+    - [C](#c)
+    - [C++](#c-1)
+    - [Python](#python)
+    - [Java](#java)
+    - [MATLAB/Simulink](#matlabsimulink)
+    - [Rust](#rust)
+  - [Tools](#tools) 
+- [FMI 3](#fmi-3) 
 - [Community](#community)
 
 
-## Libraries
+## FMI 2 
 
-Libraries to import, simulate and export FMUs (Functional Mock-up Units). 
+The latest (as of April 2020) stable release of the FMI specification is `2.0.1`, released on 2019-10-31 .
+You can find the text of the FMI specification 2.0.1 at https://github.com/modelica/fmi-standard/releases/tag/v2.0.1 . 
+Unless noted  otherwise, the tools and libraries listed are compatible with FMI 2.
 
-### C 
+### Libraries
+
+Libraries to import, simulate and export FMUs (Functional Mock-up Units) that support FMI 2. 
+
+#### C 
 - [FMI Library](http://jmodelica.org/FMILibrary) - C library for import of FMUs. [BSD] 
 - [FMU SDK](https://www.qtronic.de/en/fmusdk.html) - C library for exporting FMUs. [BSD]
 
-### C++
+#### C++
 - [FMI++](https://sourceforge.net/projects/fmipp/) - C++ library for import and export of FMUs. [BSD]
 - [FMI4cpp](https://github.com/NTNU-IHB/FMI4cpp) - FMI 2.0 implementation written in modern C++. [MIT]
 
-### Python
+#### Python
 - [PyFMI](http://www.pyfmi.org/) - Python package for loading and interacting with FMUs, based on the FMI Library. [LGPL]
 - [FMPy](https://github.com/CATIA-Systems/FMPy) - Python package for loading and interacting with FMUs. It supports also the latest [System Structure and Parameterization (SSP standard)](https://www.modelica.org/projects). [BSD]
 - [FMI++ Python Interface](https://pypi.python.org/pypi/fmipp) - Python interface for the FMI++ library. [BSD, BOOST]
@@ -38,22 +46,22 @@ Libraries to import, simulate and export FMUs (Functional Mock-up Units).
 - [modestpy](https://github.com/sdu-cfei/modest-py) - Python package for parameter estimation in FMUs. [BSD]
 - [PythonFMU](https://github.com/NTNU-IHB/PythonFMU) - Framework for exporting Python code as FMUs. [MIT]
 
-### Java
+#### Java
 - [FMI4j](https://github.com/NTNU-IHB/FMI4j) - Java/Kotlin library for dealing with FMUs on the JVM platform. [MIT]
 - [javaFMI](https://bitbucket.org/siani/javafmi) - Java library for import and export of FMUs. [LGPL3]
 
-### MATLAB/Simulink
+#### MATLAB/Simulink
 - [Simulink FMU Importing](https://mathworks.com/help/simulink/in-product-solutions.html)/[Export a Model as a Tool-Coupling FMU](https://mathworks.com/help/simulink/ug/_mw_54e936ec-2fa7-4418-be70-d99c8f91d2bd.html) - Out-of-the-box official support for FMU import and export (tool coupling) in Simulink. [Commercial]
 - [FMI Toolbox for MATLAB/Simulink](https://www.modelon.com/products-services/modelon-deployment-suite/fmi-toolbox/) - Toolbox with support for Simulink FMU Import/Export and MATLAB FMU import. [Commercial]
 - [matlab-fmu](https://sourceforge.net/projects/matlab-fmu/) - MATLAB Toolbox for Windows with support for import of FMUs for Model-Exchange and Co-Simulation as well as the export of MATLAB scripts as FMUs for Co-Simulation, based on the FMI++ library. [BSD]
 - [Simulix](https://github.com/Kvixen/Simulix) - A third-party Simulink tool to generate FMUs from Simulink models using the C-API. [GPL3]
 - [FMIKit-Simulink](https://github.com/CATIA-Systems/FMIKit-Simulink) - Import and export Functional Mock-up Units with Simulink. [BSD]
 
-### Rust
+#### Rust
 - [rust-fmi](https://crates.io/crates/fmi) - A Rust interface to FMUs (Functional Mockup Units) that follow the FMI Standard. [APACHE2/MIT]
 
-## Tools 
-For the official list of tools that support FMI, check http://fmi-standard.org/tools/ . 
+### Tools 
+For the official list of tools that support FMI 2, check http://fmi-standard.org/tools/ . 
 
 - [λ-Sim](https://github.com/mbonvini/LambdaSim) - Tool that converts FMU simulation models into REST APIs. [MIT]
 - [FMIGo!](http://www.fmigo.net/) - A set of tools for dealing with the FMI and SSP standards. [MIT]
@@ -63,7 +71,22 @@ For the official list of tools that support FMI, check http://fmi-standard.org/t
 - [ROS fmi_adapter](https://github.com/boschresearch/fmi_adapter) - FMI support for [ROS](http://www.ros.org/), a flexible framework for writing robot software. [APACHE2]
 - [fmi_adapter_ros2](https://github.com/boschresearch/fmi_adapter_ros2) - FMI support for [ROS2](https://index.ros.org/doc/ros2/), the new version of the Robot Operating System. [APACHE2]
 
+## FMI 3
+
+
+FMI 3.0  development is currently in Alpha phase. General information on the FMI 3.0 feature list can be found in https://fmi-standard.org/faq/, and the development is ongoing on the repo https://github.com/modelica/fmi-standard . You can find the latest, automatically generated version of the FMI 3.0 alpha standard at https://fmi-standard.org/docs/3.0-dev/ .
+
+**Warning: FMI 3.0 is still under heavy development, and most of the tools listed in the following they support it only in an experimental way. If you want stable tools, use FMI 2 for the time being.**
+
+Some of the libraries listed in the previous section also have prototypal support for FMI 3 alpha: 
+
+- **Python:** [fmpy](https://github.com/CATIA-Systems/FMPy)  some support for FMI 3 is available in the [`develop`](https://github.com/CATIA-Systems/FMPy/tree/develop) branch.
+- **Simulink:** [FMIKit-Simulink](https://github.com/CATIA-Systems/FMIKit-Simulink) - Experimental export of 3.0 FMUs seems available with `grtfmi.tlc` target since `v2.8-alpha.1`, but it  still does not does not comply with FMI `3.0-alpha.3` specification. 
+- **Examples**: [Reference-FMUs](https://github.com/modelica/Reference-FMUs) : `3.0-alpha.3` examples FMUs are available, including examples for new co-simulation features such as scheduled co-simulation and early return in co-simulation.
+
+
 ## Community
+
 - [Stack Overflow](https://stackoverflow.com/tags/fmi) - Questions related to FMI in Stack Overflow. 
 - [Twitter's FMI Info and News](https://twitter.com/fmi_info) - Unofficial news account about the FMI Standard, FMI usage and FMI tools.
 


### PR DESCRIPTION
For the time being it is better to strictly separate FMI 2 and  FMI 3 sections.
In the future once FMI 3 is released and (hopefully) a lot of tools and libraries will start supporting  it, it will probably make more sense to merge the FMI 2 and FMI 3 section and specify for each library  or tool which version of the FMI standard it supports.

If you could review the text @chrbertsch it would be great, thanks! 