### PR TITLE
add qfmu

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Libraries to import, simulate and export FMUs (Functional Mock-up Units) that su
 - [SimulatorToFMU](https://github.com/LBNL-ETA/SimulatorToFMU) - Python package that allows to export a memoryless Python-driven simulation program or script as a FMU. [BSD]
 - [modestpy](https://github.com/sdu-cfei/modest-py) - Python package for parameter estimation in FMUs. [BSD]
 - [PythonFMU](https://github.com/NTNU-IHB/PythonFMU) - Framework for exporting Python code as FMUs. [MIT]
-- [qFMU](https://github.com/hyumo/qFMU) - Generate standard form system FMUs through CLI [BSD]
+- [qFMU](https://github.com/hyumo/qFMU) - Generate standard LTI system FMUs through CLI [BSD]
 
 #### Java
 - [FMI4j](https://github.com/NTNU-IHB/FMI4j) - Java/Kotlin library for dealing with FMUs on the JVM platform. [MIT]

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Libraries to import, simulate and export FMUs (Functional Mock-up Units) that su
 - [SimulatorToFMU](https://github.com/LBNL-ETA/SimulatorToFMU) - Python package that allows to export a memoryless Python-driven simulation program or script as a FMU. [BSD]
 - [modestpy](https://github.com/sdu-cfei/modest-py) - Python package for parameter estimation in FMUs. [BSD]
 - [PythonFMU](https://github.com/NTNU-IHB/PythonFMU) - Framework for exporting Python code as FMUs. [MIT]
+- [qFMU](https://github.com/hyumo/qFMU) - Generate standard form system FMUs through CLI [BSD]
 
 #### Java
 - [FMI4j](https://github.com/NTNU-IHB/FMI4j) - Java/Kotlin library for dealing with FMUs on the JVM platform. [MIT]


### PR DESCRIPTION
- An FMU generation tool
- Generate LTI system FMUs through the command line interface
- Only Python3.8+ and a C compiler are needed